### PR TITLE
Add branch name to git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ It will allow you to build all versions instead of only the latest.
 
 Submodules are initialized and updated recursively.
 
+Note: the name of the branch from which the pull request has been created is stored in the special git config `pullrequest.branch` so that you can use it as reference in your pipeline.
+
 #### Parameters
 
 * `depth`: *Optional.* If a positive integer is given, *shallow* clone the repository using the `--depth` option. Using this flag voids your warranty.

--- a/assets/in
+++ b/assets/in
@@ -132,12 +132,30 @@ if [ -z "$target_commit" ]; then
   exit 1
 fi
 
+# parse uri and retrieve host
+uri_parser "$uri"
+repo_host="${uri_schema}://${uri_address}"
+repo_host=${repo_host}$(getBasePathOfBitbucket)
+
+# determine repository name for calling REST api
+repo_name=$(basename "$uri" | sed "s/.git$//")
+repo_project=$(basename $(dirname "$uri"))
+
+# verify target branch of prq
+prq=$(bitbucket_pullrequest "$repo_host" "$repo_project" "$repo_name" "$prq_id" "" "$skip_ssl_verification")
+
+if [ "$prq" != "ERROR" ]; then
+  branch=$(echo "$prq" | jq -r '.fromRef.displayId')
+fi
+
+
 # expose configuration of pull request that can be used in container
 git config --add pullrequest.id $prq_id
 git config --add pullrequest.source $source_commit
 git config --add pullrequest.target $target_commit
 git config --add pullrequest.merge $ref
 git config --add pullrequest.date "$prq_date"
+git config --add pullrequest.branch "$branch"
 
 jq -n "{
   version: $(jq '.version' < "$payload"),


### PR DESCRIPTION
When this resource is used to checkout a pull request's branch, it uses a special name as the branch (in the form pullrequest/{id}/merge.

This change add the original name of the branch as a git config setting so that it can be retrieved and used by other tasks in the pipeline.