### PR TITLE
Fix error on pull requests that are already merged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM gliderlabs/alpine:edge
 
 RUN apk --no-cache add \
   bash=4.4.19-r1 \
-  ca-certificates=20171114-r0 \
-  curl=7.59.0-r0 \
-  git=2.16.3-r0 \
-  jq=1.5-r5 \
-  openssh-client=7.7_p1-r0
+  ca-certificates=20171114-r3 \
+  curl=7.59.0-r1 \
+  git=2.17.0-r0 \
+  jq=1.6_rc1-r1 \
+  openssh-client=7.7_p1-r2
 
 # can't `git pull` unless we set these
 RUN git config --global user.email "git@localhost" && \

--- a/assets/check
+++ b/assets/check
@@ -84,7 +84,7 @@ if [ -n "$PULL_REQUESTS" ]; then
     # verify target branch of prq
     prq=$(bitbucket_pullrequest "$repo_host" "$repo_project" "$repo_name" "$prq_number" "" "$skip_ssl_verification")
 
-    if [ "$prq" = "ERROR" ]; then
+    if [ "$prq" = "NO_SUCH_PULL_REQUEST" ]; then
       continue
     fi
 
@@ -97,6 +97,10 @@ if [ -n "$PULL_REQUESTS" ]; then
 
       if [ "$only_when_mergeable" == "true" -o "$only_without_conflicts" == "true" ]; then
         prq_merge=$(bitbucket_pullrequest_merge "$repo_host" "$repo_project" "$repo_name" "$prq_number" "" "$skip_ssl_verification")
+
+        if [ "$prq_merge" = "ALREADY_MERGED" ]; then
+          continue
+        fi
 
         # verify if prq has merge conflicts
         conflicted=$(echo "$prq_merge" | jq -r '.conflicted')

--- a/assets/helpers/bitbucket.sh
+++ b/assets/helpers/bitbucket.sh
@@ -72,8 +72,11 @@ bitbucket_request() {
     jq -c '.values' < "$request_result"
   elif [ "$(jq -c '.errors' < "$request_result")" == "null" ]; then
     jq '.' < "$request_result"
-  elif [ "${request_result/NoSuchPullRequestException}" = "${request_result}" ]; then
-    printf "ERROR"
+  elif grep -q NoSuchPullRequestException "$request_result"; then
+    printf "NO_SUCH_PULL_REQUEST"
+    return
+  elif grep -q 'This pull request has already been merged' "$request_result"; then
+    printf "ALREADY_MERGED"
     return
   else
     log "Bitbucket request ($request_url) failed: $(cat $request_result)"

--- a/scripts/test
+++ b/scripts/test
@@ -17,5 +17,5 @@ docker run --interactive --rm --volume "$PWD:/mnt" koalaman/shellcheck \
   /mnt/scripts/test
 set -e
 
-docker build --rm --tag mm62/concourse-bitbucket-pullrequest-resource-test .
+docker build --pull --rm --tag mm62/concourse-bitbucket-pullrequest-resource-test .
 docker rmi mm62/concourse-bitbucket-pullrequest-resource-test


### PR DESCRIPTION
The refs/pull-requests/nn refs remain for some merged and closed pull
requests. They return IllegalPullRequestStateException when the merge is
requested.

The check for NoSuchPullRequestException was checking the file name and
not the contents of the file.