### PR TITLE
Fix error on pull requests that are declined

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -98,7 +98,7 @@ if [ -n "$PULL_REQUESTS" ]; then
       if [ "$only_when_mergeable" == "true" -o "$only_without_conflicts" == "true" ]; then
         prq_merge=$(bitbucket_pullrequest_merge "$repo_host" "$repo_project" "$repo_name" "$prq_number" "" "$skip_ssl_verification")
 
-        if [ "$prq_merge" = "ALREADY_MERGED" ]; then
+        if [ "$prq_merge" = "ALREADY_MERGED" ] || [ "$prq_merge" = "DECLINED" ]; then
           continue
         fi
 

--- a/assets/helpers/bitbucket.sh
+++ b/assets/helpers/bitbucket.sh
@@ -78,6 +78,9 @@ bitbucket_request() {
   elif grep -q 'This pull request has already been merged' "$request_result"; then
     printf "ALREADY_MERGED"
     return
+  elif grep -q 'This pull request has been declined and must be reopened before it can be merged' "$request_result"; then
+    printf "DECLINED"
+    return
   else
     log "Bitbucket request ($request_url) failed: $(cat $request_result)"
     exit 1


### PR DESCRIPTION
The refs/pull-requests/nn refs remain for some declined pull requests.
They return IllegalPullRequestStateException when the merge is
requested.