### PR TITLE
Switch from gliderlabs/alpine to official alpine for docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM gliderlabs/alpine:edge
+FROM alpine:3.7
 
 RUN apk --no-cache add \
   bash=4.4.19-r1 \
-  ca-certificates=20171114-r3 \
-  curl=7.59.0-r1 \
-  git=2.17.0-r0 \
-  jq=1.6_rc1-r1 \
-  openssh-client=7.7_p1-r2
+  ca-certificates=20171114-r0 \
+  curl=7.60.0-r1 \
+  git=2.15.0-r1 \
+  jq=1.5-r5 \
+  openssh-client=7.5_p1-r8
 
 # can't `git pull` unless we set these
 RUN git config --global user.email "git@localhost" && \


### PR DESCRIPTION
For more stable package versions.