### PR TITLE
Expose base branch & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,19 @@ It will allow you to build all versions instead of only the latest.
 
 Submodules are initialized and updated recursively.
 
-Note: the name of the branch from which the pull request has been created is stored in the special git config `pullrequest.branch` so that you can use it as reference in your pipeline.
+Note: this resource stores some parameters in the git config. Here is the list:
+
+| Key                  | Comment                |
+| -------------------- | ---------------------- |
+| `pullrequest.id`     | Pull request ID.       |
+| `pullrequest.source` | Source git commit ref. |
+| `pullrequest.target` | Target git commit ref. |
+| `pullrequest.merge`  | Merge commit ref.      |
+| `pullrequest.date`   | PR date.               |
+| `pullrequest.branch` | Source branch.         |
+| `pullrequest.base`   | Target branch.         |
+
+Run `$ git config [key]` to retrieve data.
 
 #### Parameters
 

--- a/assets/in
+++ b/assets/in
@@ -148,6 +148,7 @@ if [ "$prq" != "NO_SUCH_PULL_REQUEST" ] && \
    [ "$prq" != "ALREADY_MERGED" ] && \
    [ "$prq" != "DECLINED" ]; then
   branch=$(echo "$prq" | jq -r '.fromRef.displayId')
+  base_branch=$(echo "$prq" | jq -r '.toRef.displayId')
 fi
 
 
@@ -158,6 +159,7 @@ git config --add pullrequest.target $target_commit
 git config --add pullrequest.merge $ref
 git config --add pullrequest.date "$prq_date"
 git config --add pullrequest.branch "$branch"
+git config --add pullrequest.base "$base_branch"
 
 jq -n "{
   version: $(jq '.version' < "$payload"),


### PR DESCRIPTION
Hi! Thanks for the great resource.

We collect coverage using SonarQube, which requires base branch to be specified for PR analysis mode to work correctly. Unfortunately, this resource didn't expose the base branch, so I added it.

I also updated the docs so all exposed parameters are now listed in the README.